### PR TITLE
Adding Plotly Charts for CPC Distributions over time

### DIFF
--- a/Func_CPC_Trends.R
+++ b/Func_CPC_Trends.R
@@ -1,0 +1,67 @@
+CPC_Trend_Vis <- function(combined = IN_patent_data_combined, type){
+  
+  combined <- data.table(combined)[, 
+                                   .(cpc_section_id, patent_year)]
+  combined[cpc_section_id == "A", cpc_section_title := "Human Necessities"]
+  combined[cpc_section_id == "B", cpc_section_title := "Operations and Transport"]
+  combined[cpc_section_id == "C", cpc_section_title := "Chemistry and Metallurgy"]
+  combined[cpc_section_id == "D", cpc_section_title := "Textiles"]
+  combined[cpc_section_id == "E", cpc_section_title := "Fixed Constructions"]
+  combined[cpc_section_id == "F", cpc_section_title := "Mechanical Engineering"]
+  combined[cpc_section_id == "G", cpc_section_title := "Physics"]
+  combined[cpc_section_id == "H", cpc_section_title := "Electricity"]
+
+  
+  combined_yr <- combined[!is.na(cpc_section_title), .(
+    patents = .N
+  ), by = .(cpc_section_title, patent_year)] %>%
+    .[, pct_year := patents/sum(patents), by = patent_year]
+  
+  if(type == "absolute"){
+    p <- plot_ly(combined_yr[, .(patent_year, patents, pct_year, cpc_section_title)],
+                 x = ~patent_year,
+                 y = ~patents,
+                 name = ~cpc_section_title,
+                 color = ~cpc_section_title,
+                 type = 'scatter',
+                 mode = 'lines',
+                 hoverinfo = 'text',
+                 #fill = 'tozeroy',
+                 text = ~paste0(cpc_section_title, " (",patent_year,")\n",
+                                "# of Patents: ", patents %>% comma, "\n",
+                                "% of Year: ", pct_year %>% percent)
+                ) %>%
+                  layout(
+                    title = "CPC Section Distribution Over Time",
+                    xaxis = list(title = "Patent Grant Year", showgrid = FALSE),
+                    yaxis = list(title = "Number of Patents Granted", showgrid = FALSE)
+                  )
+    
+  }
+  else if (type == 'relative'){
+    p<- plot_ly(combined_yr,
+            x = ~patent_year,
+            y = ~pct_year*100,
+            name = ~fct_rev(cpc_section_title),
+            color = ~fct_rev(cpc_section_title),
+            type = 'bar',
+            hoverinfo = 'text',
+            #fill = 'tozeroy',
+            text = ~paste0(cpc_section_title, " (",patent_year,")\n",
+                           "# of Patents: ", patents %>% comma, "\n",
+                           "% of Year: ", pct_year %>% percent)
+      ) %>%
+        layout(
+          barmode = 'stack',
+          title = "CPC Section Distribution Over Time",
+          xaxis = list(title = "Patent Grant Year", showgrid = FALSE),
+          yaxis = list(title = "% Of Patent Grants in Year", showgrid = FALSE, ticksuffix = "%")
+        )
+      
+  }
+ 
+  output_list <- list(data = combined_yr, vis=p) 
+  
+  return(output_list)
+}
+  

--- a/global.R
+++ b/global.R
@@ -14,6 +14,7 @@ library(DT)
 library(shinycssloaders)
 library(leaflet)
 library(leaflet.extras)
+library(plotly)
 
 
 
@@ -24,6 +25,7 @@ source("Func_Network_Vis.R")
 source("Func_Pull_Data.R")
 source("Func_Vis_Circular.R")
 source("Func_CPC_Treemap_Vis.R")
+source("Func_CPC_Trends.R")
 
 #load data
 IN_patent_data_combined <- readRDS("IN_patent_data_combined.RDS")

--- a/server.R
+++ b/server.R
@@ -88,13 +88,14 @@ shinyServer(function(input, output, session) {
     Treemap_Func()$vis
   })
   
+  ##CPC Trends Tabs
+  output$cpc_absolute_trends <- renderPlotly({
+    CPC_Trend_Vis(type = 'absolute')$vis
+  })
   
-  # observe({
-  #   updateSliderInput(session, "patent_year_range",
-  #                     min = min(Treemap_Vis()$data$year_granted), 
-  #                     max = max(Treemap_Vis()$data$year_granted))
-  #   
-  # })
+  output$cpc_relative_trends <- renderPlotly({
+    CPC_Trend_Vis(type = 'relative')$vis
+  })
   
   
 })

--- a/ui.R
+++ b/ui.R
@@ -9,6 +9,7 @@ shinyUI(
         menuItem("Network Vis", tabName = "network_vis", icon = icon("sitemap")),
         menuItem("Investors/Assignees", tabName="inv_assn", icon = icon("adjust")),
         menuItem("CPC Industry Breakdown", tabName = "cpc_treemap", icon = icon("angle-double-down")),
+        menuItem("CPC Industry Trends", tabName = "cpc_trends", icon = icon("line-chart")),
         menuItem("Pull New Data", tabName = "pull_data", icon = icon("database"))
       )
     ),
@@ -123,6 +124,13 @@ shinyUI(
                    plotOutput("tree_map") %>% withSpinner()
             )
           )
+        ),
+        tabItem(tabName ="cpc_trends",
+                tabsetPanel(
+                  type='tabs',
+                  tabPanel("CPC Trends (Absolute)", plotlyOutput("cpc_absolute_trends") %>% withSpinner()),
+                  tabPanel("CPC Trends (Relative)", plotlyOutput("cpc_relative_trends") %>% withSpinner())
+                )
         ),
         tabItem(tabName = "pull_data",
           fluidRow(


### PR DESCRIPTION
Adding 2 plotly charts to the distribution of CPC Sections overtime in both an absolute number of patents and relative % of patents in that year.